### PR TITLE
fix: return a promise to have it awaited

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,7 +108,7 @@ export default function (options: VitePluginCompression = {}): Plugin {
         mtimeCache.set(filePath, Date.now())
       })
 
-      Promise.all(handles).then(() => {
+      return Promise.all(handles).then(() => {
         if (verbose) {
           handleOutputLogger(config, compressMap, algorithm)
           success()


### PR DESCRIPTION
There was one file that didn't get compressed and I suspected that some promise isn't being awaited. After making this fix the plugin now works for me (apart from https://github.com/vbenjs/vite-plugin-compression/issues/13).